### PR TITLE
feat: user logout API

### DIFF
--- a/src/routes/user-route.ts
+++ b/src/routes/user-route.ts
@@ -63,4 +63,23 @@ export const userRoute = new Elysia()
 
     set.status = 200;
     return { data: hasil.user };
+  })
+  .delete('/api/users/logout', async ({ headers, set }) => {
+    const authHeader = headers['authorization'] as string;
+    
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      set.status = 401;
+      return { error: 'Unauthorized' };
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+    const hasil = await userService.logout(token);
+
+    if (!hasil.berhasil) {
+      set.status = 401;
+      return { error: 'Unauthorized' };
+    }
+
+    set.status = 200;
+    return { data: 'OK' };
   });

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -64,6 +64,17 @@ class UserService {
       }
     };
   }
+
+  async logout(token: string) {
+    const session = await db.select().from(sessions).where(eq(sessions.token, token));
+    if (session.length === 0) {
+      return { berhasil: false };
+    }
+
+    await db.delete(sessions).where(eq(sessions.token, token));
+
+    return { berhasil: true };
+  }
 }
 
 export const userService = new UserService();


### PR DESCRIPTION
## Summary
- Implementasi endpoint DELETE /api/users/logout
- Hapus session dari tabel sessions berdasarkan token

## Changes
- Add logout() method ke user-service
- Add DELETE /api/users/logout route

## API
DELETE /api/users/logout
- Header: Authorization: Bearer <token>
- Success: {"data": "OK"}
- Error: {"error": "Unauthorized"}